### PR TITLE
Fix optional parameters in a module's configuration options

### DIFF
--- a/bot_modules.lua
+++ b/bot_modules.lua
@@ -488,11 +488,11 @@ function Bot:LoadModule(moduleTable)
 			for configName, configValue in pairs(configTable) do
 				local expectedType = validConfigOptions[configName][1]
 				if (not expectedType) then
-					return false, string.format("Option #%s has invalid key \"%s\"", optionIndex, configName)
+					return false, string.format("[%s] Option #%s has invalid key \"%s\"", configTable.Name, optionIndex, configName)
 				end
 
 				if (expectedType ~= "any" and type(configValue) ~= expectedType) then
-					return false, string.format("Option #%s has key \"%s\" which has invalid type %s (expected %s)", optionIndex, configName, type(configValue), expectedType)
+					return false, string.format("[%s] Option #%s has key \"%s\" which has invalid type %s (expected %s)", configTable.Name, optionIndex, configName, type(configValue), expectedType)
 				end
 			end
 
@@ -511,7 +511,7 @@ function Bot:LoadModule(moduleTable)
 			end
 
 			if (configTable.Default == nil and not configTable.Optional) then
-				return false, string.format("Option #%s is not optional and has no default value", optionIndex)
+				return false, string.format("[%s] Option #%s is not optional and has no default value", configTable.Name, optionIndex)
 			end
 
 			if (configTable.Global) then

--- a/bot_modules.lua
+++ b/bot_modules.lua
@@ -9,7 +9,7 @@ local wrap = coroutine.wrap
 local isReady = false
 
 local function code(str)
-    return string.format('```\n%s```', str)
+	return string.format('```\n%s```', str)
 end
 
 -- Maps event name to function to retrieve its guild
@@ -461,6 +461,7 @@ function Bot:LoadModule(moduleTable)
 	local globalConfig = {}
 	if (moduleTable.GetConfigTable) then
 		local success, ret = self:CallModuleFunction(moduleTable, "GetConfigTable")
+
 		if (not success) then
 			return false, "Failed to load config: " .. ret
 		end
@@ -509,7 +510,7 @@ function Bot:LoadModule(moduleTable)
 				end
 			end
 
-			if (not configTable.Default and not configTable.Optional) then
+			if (configTable.Default == nil and not configTable.Optional) then
 				return false, string.format("Option #%s is not optional and has no default value", optionIndex)
 			end
 


### PR DESCRIPTION
There was an issue when setting a module's configuration item to have a default value of `false` but not specifying that it should be optional. 

The `not` operator was coercing the received `false` value instead of checking if the value was `nil` in order to reject the module because of bad configuration. 

This PR fixes this by correctly checking the content of the `Default` parameter of a configuration option of a module. 

Additionally, this PR adds the module name in the error message when an error occurs.