### PR TITLE
Allow deletion of the command or message that triggers a quote

### DIFF
--- a/bot_modules.lua
+++ b/bot_modules.lua
@@ -488,11 +488,11 @@ function Bot:LoadModule(moduleTable)
 			for configName, configValue in pairs(configTable) do
 				local expectedType = validConfigOptions[configName][1]
 				if (not expectedType) then
-					return false, string.format("Option #%s has invalid key \"%s\"", optionIndex, configName)
+					return false, string.format("[%s] Option #%s has invalid key \"%s\"", configTable.Name, optionIndex, configName)
 				end
 
 				if (expectedType ~= "any" and type(configValue) ~= expectedType) then
-					return false, string.format("Option #%s has key \"%s\" which has invalid type %s (expected %s)", optionIndex, configName, type(configValue), expectedType)
+					return false, string.format("[%s] Option #%s has key \"%s\" which has invalid type %s (expected %s)", configTable.Name, optionIndex, configName, type(configValue), expectedType)
 				end
 			end
 
@@ -511,7 +511,7 @@ function Bot:LoadModule(moduleTable)
 			end
 
 			if (configTable.Default == nil and not configTable.Optional) then
-				return false, string.format("Option #%s is not optional and has no default value", optionIndex)
+				return false, string.format("[%s] Option #%s is not optional and has no default value", configTable.Name, optionIndex)
 			end
 
 			if (configTable.Global) then

--- a/bot_modules.lua
+++ b/bot_modules.lua
@@ -9,7 +9,7 @@ local wrap = coroutine.wrap
 local isReady = false
 
 local function code(str)
-    return string.format('```\n%s```', str)
+	return string.format('```\n%s```', str)
 end
 
 -- Maps event name to function to retrieve its guild
@@ -461,6 +461,7 @@ function Bot:LoadModule(moduleTable)
 	local globalConfig = {}
 	if (moduleTable.GetConfigTable) then
 		local success, ret = self:CallModuleFunction(moduleTable, "GetConfigTable")
+
 		if (not success) then
 			return false, "Failed to load config: " .. ret
 		end
@@ -509,7 +510,7 @@ function Bot:LoadModule(moduleTable)
 				end
 			end
 
-			if (not configTable.Default and not configTable.Optional) then
+			if (configTable.Default == nil and not configTable.Optional) then
 				return false, string.format("Option #%s is not optional and has no default value", optionIndex)
 			end
 


### PR DESCRIPTION
This PR, which is dependent on #17, adds two new configuration options. 

The new `DeleteInvokationOnAutoQuote` setting allows to automatically delete the message that triggers a quote when auto-quoting. This setting defaults to `false`. 

![](https://i.imgur.com/sIWBVSu.gif)

The new `DeleteInvokationOnManualQuote` setting allows to automatically delete the message when using the `!quote` command. This setting defaults to `false`. 

![](https://i.imgur.com/QT3qkkh.gif)

Additionally, a new optional parameter for the `!quote` command has been added. This boolean parameter determines if the command should be deleted. 

![](https://i.imgur.com/t9RlrL2.gif)

For instance, `!quote 674011949842825235 true` will quote a message and then delete the command. 

Also, if `DeleteInvokationOnManualQuote` is set to true, but `false` is passed as the second parameter of `!quote`, the command will not be deleted (eg. `!quote 674011949842825235 false` won't delete the command). 

![](https://i.imgur.com/QDiI3Qy.gif)