### PR TITLE
[CRITICAL] Fixes bots being able to call commands

### DIFF
--- a/bot_commands.lua
+++ b/bot_commands.lua
@@ -66,7 +66,8 @@ function Bot:RegisterCommand(values)
 		Help = values.Help,
 		Name = name,
 		PrivilegeCheck = values.PrivilegeCheck,
-		Silent = values.Silent ~= nil and values.Silent
+		Silent = values.Silent ~= nil and values.Silent,
+		BotAware = values.BotAware ~= nil and values.BotAware
 	}
 
 	self.Commands[name] = command
@@ -96,6 +97,10 @@ Bot.Client:on('messageCreate', function(message)
 
 	local commandTable = Bot.Commands[commandName]
 	if (not commandTable) then
+		return
+	end
+
+	if (not commandTable.BotAware and message.author.bot) then
 		return
 	end
 


### PR DESCRIPTION
## This is a critical issue, please merge it as soon as possible

Adds a BotAware parameter when registering function, defaulted to false, which specify if a bot can call a specific command.
Maybe it will be useless, but I don't want to remove such an ability.

**Example of a minimal hello world module, triggerable by a bot**
```
Module.Name = "helloworld"

function Module:OnLoaded()
    Bot:RegisterCommand({
        Name = "helloworld",
        Args = {},
        BotAware = true,
    
        Help = "Just an example of bot aware command",
        Func = function (message)
            message:reply("Hello world!")
        end
    })

    return true
end
```

**This is critical because it applies to nearly all commands. As long as the bot has the administrator permission, it can call every command, except those reserved to the instance owner.**

For example, Carlbot has an `echo` command, and with that, it is possible to activate the ban module, and then to ban someone