### PR TITLE
Poll: PR some very old changes (removes goto, improves UX)

### DIFF
--- a/module_poll.lua
+++ b/module_poll.lua
@@ -459,6 +459,11 @@ function Module:OnLoaded()
 				end
 
 				local channel = guild:getChannel(poll.channel)
+				if channel == nil then
+					polls[member.id] = nil
+					commandMessage:reply("Poll was cancelled because the destination channel was deleted")
+					return
+				end
 				local data = self:GetPersistentData(guild)
 				local message = channel:send({
 					embed = self:FormatPoll(member, {}, nil, false)

--- a/module_poll.lua
+++ b/module_poll.lua
@@ -349,7 +349,7 @@ function Module:OnLoaded()
 			local poll = polls[member.id]
 
 			if (not poll) then
-				commandMessage:reply("You must create a poll in order to use this command!")
+				commandMessage:reply("You must create a poll in order to use this command! Just use the command `createpoll`")
 				return
 			end
 


### PR DESCRIPTION
This was done back 4 months ago, but I wanted to add support for something more before to PR this. I just forgot what it was but it was to send a dm to the author of the poll when something went wrong.
Anyway, I think this is still good. I plan to do some more changes to the poll module, in order to improve it, but before to do it, I want this old thing merged.

## Content
- Send a private message when a poll is forced cancelled
- Check if channel was deleted before to send a poll
- Improve UX
