### PR TITLE
Warn Module update + started documentation + added guild aware permission checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Not a Bot
 
 Source code of the bot of the french programming discord server NaN (Not a Name).  https://discord.gg/zcWp9sC
+
+[Documentation (WIP)](doc/index.md)

--- a/bot_commands.lua
+++ b/bot_commands.lua
@@ -61,12 +61,21 @@ function Bot:RegisterCommand(values)
 		error("Command \"" .. name .. " already exists")
 	end
 
+	if (values.PrivilegeCheck and not values.GuildAwarePrivilegeCheck) then
+		values.GuildAwarePrivilegeCheck = function (member, guild) return true end
+	end
+
+	if (values.GuildAwarePrivilegeCheck and not values.PrivilegeCheck) then
+		values.PrivilegeCheck = function (member) return true end
+	end
+
 	local command = {
 		Args = values.Args,
 		Function = values.Func,
 		Help = values.Help,
 		Name = name,
 		PrivilegeCheck = values.PrivilegeCheck,
+		GuildAwarePrivilegeCheck = values.GuildAwarePrivilegeCheck,
 		Silent = values.Silent ~= nil and values.Silent,
 		BotAware = values.BotAware ~= nil and values.BotAware
 	}
@@ -124,12 +133,14 @@ client:on('messageCreate', function(message)
 
 	if (commandTable.PrivilegeCheck) then
 	 	local success, ret = Bot:ProtectedCall("Command " .. commandName .. " privilege check", commandTable.PrivilegeCheck, message.member)
-	 	if (not success) then
+		local guildAwareSuccess, guildAwareRet = Bot:ProtectedCall("Command " .. commandName .. " guild aware privilege check", commandTable.GuildAwarePrivilegeCheck, message.member, message.guild) 
+		
+		if (not success or not guildAwareSuccess) then
 	 		message:reply("An error occurred")
 	 		return
 	 	end
 
-	 	if (not ret) then
+	 	if (not ret and not guildAwareRet) then
 			print(string.format("%s tried to use command %s on guild %s", message.author.tag, commandName, message.guild.name))
 			return
 		end

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,39 @@
+# Not a Bot - Discord Bot
+
+Not a Bot is a french moderation bot designed for the [Not a Name](https://discord.gg/zcWp9sC).
+
+It is based on multiple configurable modules where each ones have their own task. 
+
+The bot is made in Lua, with a custom wrapper around the Discordia library.
+
+## Summary
+
+### Modules
+
+- [Ban]() : Ban management module
+- [Channel]() : Channel management module
+- [Game]() : 
+- [Kick]() : Kick management
+- [Mention]() : Mention reaction module
+- [Message]() : Message handler module (includes custom commands)
+- [Modmail]() : Modmail and tickets module
+- [Modo]() : Alert and flags module
+- [Mute]() : Mute management module
+- [Pin]() : Message pinning module
+- [Poll]() : Polling module
+- [Purge]() : Purge management module
+- [Quote]() : Message quoting module
+- [Raid]() : Anti-raid module
+- [RoleInfo]() : Infos about roles
+- [Stats]() : Guild stat module
+- [Twitch]() : Twitch notification module
+- [Warn](modules/warn_module.md) : Warning module
+- [Welcome]() : Welcome message module
+
+### API
+
+
+
+### External Resources
+
+- [Discordia Library](https://github.com/SinisterRectus/Discordia)

--- a/doc/modules/warn_module.md
+++ b/doc/modules/warn_module.md
@@ -14,6 +14,14 @@ After a given amount of warns, the member gets muted __if the mute module is ena
 - Sanctions (Boolean) (default = true)
   - Enables sanctions (mute and ban alert) when a member receives a warning.
 
+- MinimalWarnRole (Role) (default = nothing)
+  - Minimal role to be able to warn members and see their histories
+  - Unlocks `warn` and `warnlist`
+
+- MinimalUnwarnRole (Role) (default = nothing)
+  - Minimal role to be able to unwarn a member.
+  - Unlocks `popwarn` and `clearwarn`
+
 - WarnAmountToMute (Integer) (default = 3)
   - Number of warns needed to mute a member.
 
@@ -28,6 +36,9 @@ After a given amount of warns, the member gets muted __if the mute module is ena
   - Channel where all the ban notifications are sent when a player has enough warnings
   - This setting is required to enable the module
   - You still have to manually ban the member, the last choice remains to the moderation team.
+
+- WarnLogChannel (Channel) (default = nothing)
+  - Channel where all the notifications about warns and unwarns are logged.
 
 - SendPrivateMessage (Boolean) (default = true)
   - Enable private messages to inform the member of his warning.
@@ -48,3 +59,6 @@ Assuming the bot prefix is `!`
 - `!clearwarns <target>`
   - Clears all the history of the given member.
   - Example : `!clearwarns @SomePlayer`
+
+- `!popwarns <target>`
+  - Removes the last warn of the targeted member

--- a/doc/modules/warn_module.md
+++ b/doc/modules/warn_module.md
@@ -1,0 +1,50 @@
+# Warn Module
+
+Back to the *[Summary](../index.md)*.
+
+*[Sources of the module](../../module_warn.lua)*
+
+The warn module is used to give members warnings about their behaviour in the guild.
+
+After a given amount of warns, the member gets muted __if the mute module is enabled__
+
+## Config
+
+
+- Sanctions (Boolean) (default = true)
+  - Enables sanctions (mute and ban alert) when a member receives a warning.
+
+- WarnAmountToMute (Integer) (default = 3)
+  - Number of warns needed to mute a member.
+
+- WarnAmountToBan (Integer) (default = 9)
+  - Numbed of warns needed to send the ban alert to the moderators.
+
+- DefaultMuteDuration (Duration) (default = 1 hour)
+  - Default mute duration when a member gets enough warnings.
+  - The duration increases as the warning amount increases: `duration = default_duration * (warnings / WarnAmountToMute)`
+
+- BanInformationChannel (Channel) (default = nothing)
+  - Channel where all the ban notifications are sent when a player has enough warnings
+  - This setting is required to enable the module
+  - You still have to manually ban the member, the last choice remains to the moderation team.
+
+- SendPrivateMessage (Boolean) (default = true)
+  - Enable private messages to inform the member of his warning.
+
+## Commands
+
+Assuming the bot prefix is `!`
+
+- `!warn <target> [reason]`
+  - This command gives a warning to the target with the given reason. It also checks if the member should receive a mute or more (only if the option is enabled).
+  - If enabled, the member will receive a private message resuming the warning and where it comes from.
+  - Example : `!warn @SomePlayer You are a terrible liar`
+
+- `!warnlist <target>`
+  - Shows all the warnings that the given user received.
+  - Example : `!warnlist @SomePlayer`
+
+- `!clearwarns <target>`
+  - Clears all the history of the given member.
+  - Example : `!clearwarns @SomePlayer`

--- a/module_warn.lua
+++ b/module_warn.lua
@@ -207,7 +207,7 @@ function Module:OnLoaded()
                     local durationStr = util.FormatTime(duration, 3)
                     local mute_module = bot:GetModuleForGuild(guild, "mute")
                     
-                    if mute_module:IsEnabledForGuild(guild) then
+                    if mute_module then
                         local channel = guild:getChannel(config.BanInformationChannel)
                         if channel then
                             channel:send(string.format("The member **%s** ( %d ) has enough warns to be muted (%d warns) for %s.",

--- a/module_warn.lua
+++ b/module_warn.lua
@@ -77,7 +77,7 @@ function Module:GetConfigTable()
 
     return {
         {
-            Name = "Sactions",
+            Name = "Sanctions",
             Description = "Enable sanctions over members.",
             Type = bot.ConfigType.Boolean,
             Default = true
@@ -99,12 +99,6 @@ function Module:GetConfigTable()
             Description = "Default mute duration when reached enough warns.",
             Type = bot.ConfigType.Duration,
             Default = 60 * 60
-        },
-        {
-            Name = "MuteRole",
-            Description = "(MUTE NOT YET IMPLEMENTED) Mute role to be applied (no need to configure its permissions)\n /!\\ The role must be the same as the role used in the Mute module. The Mute module must be enabled too.",
-            Type = bot.ConfigType.Role,
-            Default = ""
         },
         {
             Name = "BanInformationChannel",
@@ -132,12 +126,6 @@ function Module:OnEnable(guild)
     if not banInfo then
         return false, "Invalid ban information channel, check your configuration."
     end
-
-    local muteRole = config.MuteRole and guild:getRole(config.MuteRole) or nil
-    if not muteRole then
-        return false, "Invalid mute role, check your configuration."
-    end
-
 
     return true
 end

--- a/module_warn.lua
+++ b/module_warn.lua
@@ -1,0 +1,292 @@
+-- Copyright (C) 2021 Lezenn
+-- This file is part of the "Not a Bot" application
+-- For conditions of distribution and use, see copyright notice in LICENSE
+
+local client = Client
+local config = Config
+local discordia = Discordia
+local bot = Bot
+local enums = discordia.enums
+
+Module.Name = "warn"
+
+--  Storage Model
+--
+--  [
+--      {
+--          UserId: memberId,
+--          Warns: {
+--              {From: moderatorId, Reason: "...."},
+--              ...
+--          }
+--      },
+--      ...
+--  ]
+
+function FindMember(history, memberId)
+    local result = nil
+    for _idx, userHistory in ipairs(history) do
+        if userHistory.UserId == memberId then
+            result = userHistory
+            break
+        end
+    end
+    return result
+end
+
+function AddWarn(history, memberId, moderatorId, reason)
+    local member = FindMember(history, memberId)
+    if (not member) then
+        table.insert(history, {
+            UserId = memberId,
+            Warns = {
+                {
+                    From = moderatorId,
+                    Reason = reason,
+                }
+            }
+        })
+    else
+        table.insert(member.Warns, {
+            From = moderatorId,
+            Reason = reason,
+        })
+    end
+end
+
+function GetWarnAmount(history, memberId)
+    local member = FindMember(history, memberId)
+    return table.length(member.Warns)
+end
+
+function SendWarnMessage(commandMessage, targetMember, reason)
+    if not reason then
+        commandMessage:reply(string.format("**%s** has warned **%s**.", commandMessage.member.name, targetMember.name))
+    else
+        commandMessage:reply(string.format("**%s** has warned **%s** for the following reason:\n**%s**.", commandMessage.member.name, targetMember.name, reason))
+    end
+end
+
+--------------------------------
+
+function Module:CheckPermissions(member)
+    return member:hasPermission(enums.permission.banMembers)
+end
+
+function Module:GetConfigTable()
+
+    return {
+        {
+            Name = "Sactions",
+            Description = "Enable sanctions over members.",
+            Type = bot.ConfigType.Boolean,
+            Default = true
+        },
+        {
+            Name = "WarnAmountToMute",
+            Description = "Number of warns needed to mute the member.",
+            Type = bot.ConfigType.Integer,
+            Default = 3
+        },
+        {
+            Name = "WarnAmountToBan",
+            Description = "Number of warns needed to tempban the member.",
+            Type = bot.ConfigType.Integer,
+            Default = 9,
+        },
+        {
+            Name = "DefaultMuteDuration",
+            Description = "Default mute duration when reached enough warns.",
+            Type = bot.ConfigType.Duration,
+            Default = 60 * 60
+        },
+        {
+            Name = "MuteRole",
+            Description = "Mute role to be applied (no need to configure its permissions)",
+            Type = bot.ConfigType.Role,
+            Default = ""
+        },
+        {
+            Name = "BanInformationChannel",
+            Description = "Default channel where all the ban-able members are listed.",
+            Type = bot.ConfigType.Channel,
+            Default = ""
+        },
+        {
+            Name = "SendPrivateMessage",
+            Description = "Sends the warning to the user in private message.",
+            Type = bot.ConfigType.Boolean,
+            Default = true
+        }
+    }
+
+end
+
+function Module:OnEnable(guild)
+    local data = self:GetPersistentData(guild)
+    data = data or {}
+
+    return true
+end
+
+function Module:OnLoaded()
+
+    --
+    --  warn command
+    --
+    self:RegisterCommand({
+        Name = "warn",
+        Args = {
+            {Name = "target", Type = bot.ConfigType.User},
+            {Name = "reason", Type = bot.ConfigType.String, Optional = true}
+        },
+        PrivilegeCheck = function (member) return self:CheckPermissions(member) end,
+
+        Help = "Warns a member",
+        Silent = true,
+        Func = function (commandMessage, targetUser, reason)
+            local guild = commandMessage.guild
+            local config = self:GetConfig(guild)
+            local history = self:GetPersistentData(guild)
+            history = history or {}
+            
+            local targetMember = guild:getMember(targetUser)
+            local moderator = commandMessage.member
+            
+            -- Permission check
+            if targetMember then
+                local bannedByRole = moderator.highestRole
+                local targetRole = targetMember.highestRole
+                if targetRole.position >= bannedByRole.position then
+                    commandMessage:reply("You cannot warn this user due to your lower permissions.")
+                    return
+                end
+            end
+
+            -- Adding warn to the user
+            local targetId = targetUser.id
+            local moderatorId = commandMessage.member.id
+            
+            AddWarn(history, targetId, moderatorId, reason)
+
+
+            if config.SendPrivateMessage then
+                local privateChannel = targetUser:getPrivateChannel()
+                if privateChannel then
+                    privateChannel:send(string.format("You have been warned for the following reason:\n **%s**", reason))
+                end
+            end
+
+            -- Updating member state
+            SendWarnMessage(commandMessage, targetMember, reason)
+            
+            if config.Sactions then
+                local banAmount = config.WarnAmountToBan
+                local muteAmount = config.WarnAmountToMute
+                local warnAmount = GetWarnAmount(history, targetId)
+
+                if warnAmount % banAmount == 0 then
+                    -- BAN
+                    local channel = config.BanInformationChannel
+                    if channel then
+                        channel:send(string.format("The member **%s** ( %d ) has enough warns to be banned (%d).",
+                            targetMember.tag,
+                            targetMember.id,
+                            warnAmount
+                        ))
+                    end
+                    
+
+                elseif warnAmount % muteAmount == 0 then
+                    -- MUTE
+                    local duration = config.DefaultMuteDuration * (warnAmount / muteAmount)
+                    local durationStr = util.FormatTime(duration, 3)
+                    commandMessage:reply(string.format("**%s** has been muted for **%s** for the reason: having too many warns.", 
+                        targetMember.name, 
+                        durationStr
+                    ))
+                    
+                    if config.SendPrivateMessage then
+                        local privateChannel = targetMember:getPrivateChannel()
+                        if privateChannel then
+                            local durationText
+                            if (duration > 0) then
+                                durationText = "You will be unmuted in " .. durationStr
+                            else
+                                durationText = ""
+                            end
+                            privateChannel:send(string.format("You have been muted from **%s** by having too many warns.",
+                                commandMessage.guild.name    
+                            ))
+                        end
+                    end
+
+                    local success, err = self:Mute(guild, targetMember.id, duration)
+                    if success then
+                        commandMessage:reply(string.format("%s has been muted for having too many warns.", targetMember.name))
+                    else
+                        commandMessage:reply(string.format("Failed to mute %s: %s", targetMember.name, err))
+                    end
+                end
+            end
+        end
+    })
+
+    --
+    --  warnlist command
+    --
+    self:RegisterCommand({
+        Name = "warnlist",
+        Args = {
+            {Name = "targetUser", Type = bot.ConfigType.User}
+        },
+        PrivilegeCheck = function (member) return self:CheckPermissions(member) end,
+
+        Help = "Shows all the warns of a member.",
+        Silent = true,
+        Func = function(commandMessage, targetUser)
+            local guild = commandMessage.guild
+            local history = self:GetPersistentData(guild)
+            local targetMember = guild:getMember(targetUser)
+
+            local memberHistory = FindMember(history, targetMember.id)
+            if not memberHistory then
+                commandMessage:reply(string.format("The member **%s** doesn't have any warns.", targetMember.name))
+            else
+                local message = string.format("Warns of **%s**\n", targetMember.name)
+                local warns = memberHistory.Warns
+                for _idx, warn in ipairs(warns) do
+                    local moderator = guild:getMember(warn.From)
+                    local reason = warn.Reason or "No reason provided"
+                    message = message .. string.format("Warned by : **%s** for the reason:\n\t**%s**\n", moderator.name, reason)
+                end
+                commandMessage:reply(message)
+            end
+        end
+    })
+
+    return true
+end
+
+-- FROM module_mute.lua
+function Module:Mute(guild, userId, duration)
+	local config = self:GetConfig(guild)
+	local member = guild:getMember(userId)
+	if (not member) then
+		return false, "not part of guild"
+	end
+
+	local success, err = member:addRole(config.MuteRole)
+	if (not success) then
+		self:LogError(guild, "Failed to mute %s: %s", member.tag, err)
+		return false, "failed to mute user: " .. err
+	end
+
+	local persistentData = self:GetPersistentData(guild)
+	local unmuteTimestamp = duration > 0 and os.time() + duration or 0
+		
+	persistentData.MutedUsers[userId] = unmuteTimestamp
+	self:RegisterUnmute(guild, userId, unmuteTimestamp)
+
+	return true
+end

--- a/module_warn.lua
+++ b/module_warn.lua
@@ -54,11 +54,6 @@ local function AddWarn(history, memberId, moderatorId, reason)
     end
 end
 
-local function GetWarnAmount(history, memberId)
-    local member = FindMember(history, memberId)
-    return table.length(member.Warns)
-end
-
 local function SendWarnMessage(commandMessage, targetMember, reason)
     if not reason then
         commandMessage:reply(string.format("**%s** has warned **%s**.", commandMessage.member.tag, targetMember.tag))
@@ -67,10 +62,75 @@ local function SendWarnMessage(commandMessage, targetMember, reason)
     end
 end
 
+local function generateLogEmbed(title, moderator, target, message, timestamp)
+    local result = {
+        content = "",
+        embed = {
+            title = title,
+            author = {
+                name = target.tag,
+                icon_url = target.avatarURL
+            },
+            fields = {
+                {
+                    name = "Reason",
+                    value = message,
+                    inline = false
+                }
+            },
+            timestamp = timestamp
+        }
+    }
+    p(result)
+    return result
+end
+
 --------------------------------
 
-function Module:CheckPermissions(member)
-    return member:hasPermission(enums.permission.banMembers)
+function Module:LogWarn(guild, moderator, target, message, timestamp)
+    local config = self:GetConfig(guild)
+    local logChannel = guild:getChannel(config.WarnLogChannel)
+    logChannel:send(generateLogEmbed(
+        string.format("**%s** warned **%s**", moderator.tag, target.tag),
+        moderator,
+        target,
+        message,
+        timestamp
+    ))
+end
+
+function Module:LogWarnModification(guild, moderator, target, message, timestamp)
+    local config = self:getConfig(guild)
+    local logChannel = guild:getChannel(config.WarnLogChannel)
+
+    logChannel:send(generateLogEmbed(
+        string.format("**%s** made a modification upon **%s** warns"),
+        moderator,
+        target,
+        message,
+        timestamp
+    ))
+end
+
+function Module:GetWarnAmount(history, memberId)
+    local member = FindMember(history, memberId)
+    return table.length(member.Warns)
+end
+
+function Module:HasWarnRole(guild, member)
+    local config = self:GetConfig(guild)
+    local warnRole = guild:getRole(config.MinimalWarnRole)
+    local memberRole = member.highestRole
+
+    return memberRole.position >= warnRole.position
+end
+
+function Module:HasUnwarnRole(guild, member)
+    local config = self:GetConfig(guild)
+    local unwarnRole = guild:getRole(config.MinimalUnwarnRole)
+    local memberRole = member.highestRole
+
+    return memberRole.position >= unwarnRole.position
 end
 
 function Module:GetConfigTable()
@@ -81,6 +141,18 @@ function Module:GetConfigTable()
             Description = "Enable sanctions over members.",
             Type = bot.ConfigType.Boolean,
             Default = true
+        },
+        {
+            Name = "MinimalWarnRole",
+            Description = "Minimal role to warn members and see history",
+            Type = bot.ConfigType.Role,
+            Default = ""
+        },
+        {
+            Name = "MinimalUnwarnRole",
+            Description = "Minimal role to unwarn (remove last warn) of a member",
+            Type = bot.ConfigType.Role,
+            Default = "",
         },
         {
             Name = "WarnAmountToMute",
@@ -102,7 +174,13 @@ function Module:GetConfigTable()
         },
         {
             Name = "BanInformationChannel",
-            Description = "Default channel where all the ban-able members are listed.",
+            Description = "Channel where all the ban-able members are listed.",
+            Type = bot.ConfigType.Channel,
+            Default = ""
+        },
+        {
+            Name = "WarnLogChannel",
+            Description = "Channel where all the warns, unwarns, ... are logged.",
             Type = bot.ConfigType.Channel,
             Default = ""
         },
@@ -124,7 +202,22 @@ function Module:OnEnable(guild)
 
     local banInfo = config.BanInformationChannel and guild:getChannel(config.BanInformationChannel) or nil
     if not banInfo then
-        return false, "Invalid ban information channel, check your configuration."
+        return false, "Invalid BanInformationChannel, check your configuration."
+    end
+
+    local logChan = config.WarnLogChannel and guild:getChannel(config.WarnLogChannel) or nil
+    if not logChan then
+        return false, "Invalid WarnLogChannel, check your configuration."
+    end
+
+    local warnRole = config.MinimalWarnRole and guild:getRole(config.MinimalWarnRole) or nil
+    if not warnRole then
+        return false, "Invalid MinimalWarnRole setting, check your configuration."
+    end
+
+    local unwarnRole = config.MinimalUnwarnRole and guild:getRole(config.MinimalUnwarnRole) or nil
+    if not unwarnRole then
+        return false, "Invalid MinimalUnwarnRole setting, check your configuration."
     end
 
     return true
@@ -141,7 +234,9 @@ function Module:OnLoaded()
             {Name = "target", Type = bot.ConfigType.User},
             {Name = "reason", Type = bot.ConfigType.String, Optional = true}
         },
-        PrivilegeCheck = function (member) return self:CheckPermissions(member) end,
+        GuildAwarePrivilegeCheck = function (member, guild)
+            return self:HasWarnRole(guild, member)
+        end,
 
         Help = "Warns a member",
         Silent = true,
@@ -169,7 +264,7 @@ function Module:OnLoaded()
             local moderatorId = commandMessage.member.id
             
             AddWarn(history, targetId, moderatorId, reason)
-
+            self:LogWarn(guild, moderator, targetMember, reason, commandMessage.timestamp)
 
             if config.SendPrivateMessage then
                 local privateChannel = targetUser:getPrivateChannel()
@@ -188,7 +283,7 @@ function Module:OnLoaded()
             if config.Sanctions then
                 local banAmount = config.WarnAmountToBan
                 local muteAmount = config.WarnAmountToMute
-                local warnAmount = GetWarnAmount(history, targetId)
+                local warnAmount = self:GetWarnAmount(history, targetId)
 
                 if warnAmount % banAmount == 0 then
                     -- BAN
@@ -232,7 +327,9 @@ function Module:OnLoaded()
         Args = {
             {Name = "targetUser", Type = bot.ConfigType.User}
         },
-        PrivilegeCheck = function (member) return self:CheckPermissions(member) end,
+        GuildAwarePrivilegeCheck = function (member, guild) 
+            return self:HasWarnRole(guild, member)
+        end,
 
         Help = "Shows all the warns of a member.",
         Silent = true,
@@ -265,7 +362,9 @@ function Module:OnLoaded()
         Args = {
             {Name = "targetUser", Type = bot.ConfigType.User}
         },
-        PrivilegeCheck = function (member) return self:CheckPermissions(member) end,
+        GuildAwarePrivilegeCheck = function (member, guild) 
+            return self:HasUnwarnRole(guild, member)
+        end,
 
         Help = "Clears all the warns of a specified user.",
         Silent = true,
@@ -273,14 +372,84 @@ function Module:OnLoaded()
             local guild = commandMessage.guild
             local history = self:GetPersistentData(guild)
             local targetMember = guild:getMember(targetUser)
+            local moderator = commandMessage.author
 
             local memberHistory = FindMember(history, targetMember.id)
             if not memberHistory then
                 commandMessage:reply(string.format("The member **%s** (%d) already have zero warns.", targetMember.tag, targetMember.id))
             else
+                for _i, warn in ipairs(memberHistory.Warns) do
+                    self:LogWarnModification(
+                        guild, 
+                        moderator, 
+                        targetMember, 
+                        string.format("**%s** cleared the following warn of **%s** (%d).\nIt was: **%s**\n\t*From: %s*", 
+                            moderator.tag, 
+                            targetMember.tag,
+                            targetMember.id,
+                            warn.Reason,
+                            guild:getMember(warn.From).tag
+                        )
+                    )
+                end
+                
+                self:LogWarnModification(
+                    guild, 
+                    moderator, 
+                    targetMember, 
+                    string.format("**%s** cleared %d warns of **%s** (%d).", 
+                        moderator.tag, 
+                        #memberHistory.Warns,
+                        targetMember.tag,
+                        targetMember.id
+                    )
+                )
+
                 memberHistory.Warns = {}
+
                 commandMessage:reply(string.format("Cleared **%s** (%d) warns, saving.", targetMember.tag, targetMember.id))
                 bot:Save()
+            end
+        end
+    })
+
+    --
+    --  popwarn command
+    --
+    self:RegisterCommand({
+        Name = "popwarn",
+        Args = {
+            {Name = "targetUser", Type = bot.ConfigType.User}
+        },
+        GuildAwarePrivilegeCheck = function (member, guild)
+            return self:HasUnwarnRole(guild, member)
+        end,
+
+        Help = "Removes the last warn of the given user.",
+        Silent = true,
+        Func = function (commandMessage, targetUser)
+            local guild = commandMessage.guild
+            local history = self:GetPersistentData(guild)
+            local targetMember = guild:getMember(targetUser)
+            local moderator = commandMessage.author
+
+            local memberHistory = FindMember(history, targetMember.id)
+            if not memberHistory then
+                commandMessage:reply(string.format("The member **%s** (%d) already have zero warns.", targetMember.tag, targetMember.id))
+            else
+                local lastWarn = memberHistory.Warns.remove(#memberHistory.Warns)
+                self:LogWarnModification(
+                    guild, 
+                    moderator, 
+                    targetMember, 
+                    string.format("**%s** removed the last warn of **%s** (%d).\nIt was: **%s**\n\t*From: %s*", 
+                        moderator.tag, 
+                        targetMember.tag,
+                        targetMember.id,
+                        lastWarn.Reason,
+                        guild:getMember(lastWarn.From).tag
+                    )
+                )
             end
         end
     })

--- a/module_warn.lua
+++ b/module_warn.lua
@@ -185,7 +185,7 @@ function Module:OnLoaded()
             -- Updating member state
             SendWarnMessage(commandMessage, targetMember, reason)
             
-            if config.Sactions then
+            if config.Sanctions then
                 local banAmount = config.WarnAmountToBan
                 local muteAmount = config.WarnAmountToMute
                 local warnAmount = GetWarnAmount(history, targetId)

--- a/module_warn.lua
+++ b/module_warn.lua
@@ -101,7 +101,7 @@ function Module:LogWarn(guild, moderator, target, message, timestamp)
 end
 
 function Module:LogWarnModification(guild, moderator, target, message, timestamp)
-    local config = self:getConfig(guild)
+    local config = self:GetConfig(guild)
     local logChannel = guild:getChannel(config.WarnLogChannel)
 
     logChannel:send(generateLogEmbed(
@@ -272,7 +272,7 @@ function Module:OnLoaded()
                     guild, 
                     moderator, 
                     targetMember,
-                    string.format("**%s** has warned **%s**, no reason provided.", moderator.tag, targetMember.tag), 
+                    "No reason provided.", 
                     commandMessage.timestamp)
             end
 
@@ -447,7 +447,11 @@ function Module:OnLoaded()
             if not memberHistory then
                 commandMessage:reply(string.format("The member **%s** (%d) already have zero warns.", targetMember.tag, targetMember.id))
             else
-                local lastWarn = memberHistory.Warns.remove(#memberHistory.Warns)
+                local lastWarn = table.remove(memberHistory.Warns, #memberHistory.Warns)
+                local lastWarnReason = lastWarn.Reason
+                if not lastWarnReason then
+                    lastWarnReason = "No reason provided."
+                end
                 self:LogWarnModification(
                     guild, 
                     moderator, 
@@ -456,7 +460,7 @@ function Module:OnLoaded()
                         moderator.tag, 
                         targetMember.tag,
                         targetMember.id,
-                        lastWarn.Reason,
+                        lastWarnReason,
                         guild:getMember(lastWarn.From).tag
                     )
                 )

--- a/module_warn.lua
+++ b/module_warn.lua
@@ -23,7 +23,7 @@ Module.Name = "warn"
 --      ...
 --  ]
 
-function FindMember(history, memberId)
+local function FindMember(history, memberId)
     local result = nil
     for _idx, userHistory in ipairs(history) do
         if userHistory.UserId == memberId then
@@ -34,7 +34,7 @@ function FindMember(history, memberId)
     return result
 end
 
-function AddWarn(history, memberId, moderatorId, reason)
+local function AddWarn(history, memberId, moderatorId, reason)
     local member = FindMember(history, memberId)
     if (not member) then
         table.insert(history, {
@@ -54,12 +54,12 @@ function AddWarn(history, memberId, moderatorId, reason)
     end
 end
 
-function GetWarnAmount(history, memberId)
+local function GetWarnAmount(history, memberId)
     local member = FindMember(history, memberId)
     return table.length(member.Warns)
 end
 
-function SendWarnMessage(commandMessage, targetMember, reason)
+local function SendWarnMessage(commandMessage, targetMember, reason)
     if not reason then
         commandMessage:reply(string.format("**%s** has warned **%s**.", commandMessage.member.tag, targetMember.tag))
     else
@@ -186,7 +186,11 @@ function Module:OnLoaded()
             if config.SendPrivateMessage then
                 local privateChannel = targetUser:getPrivateChannel()
                 if privateChannel then
-                    privateChannel:send(string.format("You have been warned for the following reason:\n **%s**", reason))
+                    if reason then
+                        privateChannel:send(string.format("You have been warned on %s for the following reason:\n **%s**", guild.name, reason))
+                    else
+                        privateChannel:send(string.format("You have been warned on %s", guild.name))
+                    end
                 end
             end
 


### PR DESCRIPTION
Warn module:
- added !popwarn command
- added warn and unwarn roles (for permission checking)
- added log channel in configuration
- added logs for each action (excluding warnlist)

Documentation:
- created summary
- created Warn Module doc
- API documentation will come later

Bot modification:
- Added new field to modules: GuildAwarePrivilegeCheck
- Made PrivilegeCheck and GuildAwarePrivilegeCheck complementary, both of them should pass to check privileges
- GuildAwarePrivilegeCheck takes the guild and the member as parameters, enabling configuration dependent privilege checking