### PR TITLE
Adds module "nickname"

### DIFF
--- a/config.lua.default
+++ b/config.lua.default
@@ -13,6 +13,7 @@ AutoloadModules = {
 	"module_modmail.lua",
 	"module_modo.lua",
 	"module_mute.lua",
+	"module_nickname.lua",
 	"module_pin.lua",
 	"module_pm.lua",
 	"module_poll.lua",

--- a/module_nickname.lua
+++ b/module_nickname.lua
@@ -1,0 +1,88 @@
+-- Copyright (C) 2019-2020 Axel "Elanis" Soupé
+-- This file is part of the "Not a Bot" application
+-- For conditions of distribution and use, see copyright notice in LICENSE
+
+local bot = Bot
+local client = Client
+local config = Config
+local discordia = Discordia
+local enums = discordia.enums
+local fs = require("coro-fs")
+local json = require("json")
+local path = require("path")
+
+Module.Name = "nickname"
+
+function Module:OnLoaded()
+	self:RegisterCommand({
+		Name = "drynukerename",
+		Args = {},
+		PrivilegeCheck = function (member) return member:hasPermission(enums.permission.administrator) end,
+
+		Help = "Count every nickname of every user on the server.",
+		Func = function (commandMessage, time)
+			local userList = self:BuildRenamedUserList(commandMessage.guild)
+
+			if #userList == 0 then
+				commandMessage:reply("No renamed user")
+			else 
+				commandMessage:reply("This will remove custom nickname for ".. #userList .." members. Are you sure ? Type !nukerename to apply.")
+			end
+		end
+	})
+
+	self:RegisterCommand({
+		Name = "nukerename",
+		Args = {},
+		PrivilegeCheck = function (member) return member:hasPermission(enums.permission.administrator) end,
+
+		Help = "Remove every nickname of every user on the server.",
+		Func = function (commandMessage, time)
+			local userList = self:BuildRenamedUserList(commandMessage.guild)
+
+			if #userList == 0 then
+				commandMessage:reply("No renamed user")
+			else 
+				self:RemoveNicknames(commandMessage.guild, userList);
+				commandMessage:reply("Removing custom nickname for ".. #userList .." members.")
+			end
+		end
+	})
+
+	return true
+end
+
+function Module:OnEnable(guild)
+	return true
+end
+
+function Module:BuildRenamedUserList(guild, time)
+	local userList = {}
+
+	local persistentData = self:GetPersistentData(guild)
+	local purgeData = persistentData.Purge
+
+	for userId, user in pairs(guild.members) do
+		if(user.nickname ~= nil and not user:hasPermission(enums.permission.administrator)) then
+			table.insert(userList, user)
+		end
+	end
+
+	return userList
+end
+
+function Module:RemoveNicknames(guild, userList)
+	if #userList == 0 then
+		return
+	end
+
+	self:LogInfo(guild, "Begining nickname nuke ...")
+
+	for _, user in pairs(userList) do
+		self:LogInfo(guild, "Renaming %s", user.name)
+
+		user:setNickname('')
+	end
+
+	self:LogInfo(guild, "Nickname nuke ended !")
+end

--- a/module_nickname.lua
+++ b/module_nickname.lua
@@ -12,12 +12,13 @@ local json = require("json")
 local path = require("path")
 
 Module.Name = "nickname"
+Module.PageSize = 2
 
 function Module:OnLoaded()
 	self:RegisterCommand({
 		Name = "drynukerename",
 		Args = {},
-		PrivilegeCheck = function (member) return member:hasPermission(enums.permission.administrator) end,
+		PrivilegeCheck = function (member) return self:CheckRoles(member) end,
 
 		Help = "Count every nickname of every user on the server.",
 		Func = function (commandMessage, time)
@@ -34,7 +35,7 @@ function Module:OnLoaded()
 	self:RegisterCommand({
 		Name = "nukerename",
 		Args = {},
-		PrivilegeCheck = function (member) return member:hasPermission(enums.permission.administrator) end,
+		PrivilegeCheck = function (member) return self:CheckRoles(member) end,
 
 		Help = "Remove every nickname of every user on the server.",
 		Func = function (commandMessage, time)
@@ -43,8 +44,25 @@ function Module:OnLoaded()
 			if #userList == 0 then
 				commandMessage:reply("No renamed user")
 			else 
-				self:RemoveNicknames(commandMessage.guild, userList);
+				self:RemoveNicknames(commandMessage.guild, commandMessage.member, userList)
 				commandMessage:reply("Removing custom nickname for ".. #userList .." members.")
+			end
+		end
+	})
+
+	self:RegisterCommand({
+		Name = "managenicknames",
+		Args = {},
+		PrivilegeCheck = function (member) return self:CheckRoles(member) end,
+
+		Help = "Display user nicknames and a button to reset them.",
+		Func = function (commandMessage, time)
+			local userList = self:BuildRenamedUserList(commandMessage.guild)
+
+			if #userList == 0 then
+				commandMessage:reply("No renamed user")
+			else 
+				commandMessage:reply(self:BuildUserListMessage(commandMessage.guild, userList, 0))
 			end
 		end
 	})
@@ -56,14 +74,95 @@ function Module:OnEnable(guild)
 	return true
 end
 
-function Module:BuildRenamedUserList(guild, time)
+function Module:CheckRoles(member)
+	return member:hasPermission(enums.permission.manageNicknames)
+end
+
+function Module:HasHighestRolesThanTarget(user, target)
+	local bannedByRole = user.highestRole
+	local targetRole = target.highestRole
+	if (targetRole.position >= bannedByRole.position) then
+		return false
+	end
+
+	return true
+end
+
+function Module:OnInteractionCreate(interaction)
+	local guild = interaction.guild
+	if not guild then
+		return
+	end
+
+	local member = interaction.member
+	if not self:CheckRoles(member) then
+		return
+	end
+
+	local config = self:GetConfig(guild)
+
+	local interactionType = interaction.data.custom_id
+	local custom_id_start_remove = 'nickname_remove_'
+	local custom_id_start_page = 'nickname_page_'
+
+	local userList = self:BuildRenamedUserList(guild)
+
+	if #userList == 0 then
+		interaction:respond({
+			type = enums.interactionResponseType.channelMessageWithSource,
+			data = {
+				content = "No renamed user",
+				flags = enums.interactionResponseFlag.ephemeral
+			}
+		});
+		return
+	end
+
+	if string.startsWith(interactionType, custom_id_start_remove) then
+		local cmdUserId = string.sub(interactionType, string.len(custom_id_start_remove) + 1, string.len(interactionType))
+
+		for _, user in pairs(userList) do
+			if cmdUserId == user.id then
+				if not self:HasHighestRolesThanTarget(interaction.member, user) then
+					interaction:respond({
+						type = enums.interactionResponseType.channelMessageWithSource,
+						data = {
+							content = "You cannot rename that user due to your lower permissions.",
+							flags = enums.interactionResponseFlag.ephemeral
+						}
+					});
+					return
+				end
+
+				user:setNickname('')
+
+				break
+			end
+		end
+
+		interaction:respond({
+			type = enums.interactionResponseType.channelMessageWithSource,
+			data = {
+				content = "Done !",
+				flags = enums.interactionResponseFlag.ephemeral
+			}
+		})
+	elseif string.startsWith(interactionType, custom_id_start_page) then
+		local page = string.sub(interactionType, string.len(custom_id_start_page) + 1, string.len(interactionType))
+
+		interaction.message:update(self:BuildUserListMessage(guild, userList, tonumber(page)))
+
+		interaction:respond({
+			type = enums.interactionResponseType.updateMessage,
+		})
+	end
+end
+
+function Module:BuildRenamedUserList(guild)
 	local userList = {}
 
-	local persistentData = self:GetPersistentData(guild)
-	local purgeData = persistentData.Purge
-
 	for userId, user in pairs(guild.members) do
-		if(user.nickname ~= nil and not user:hasPermission(enums.permission.administrator)) then
+		if(user.nickname ~= nil) then
 			table.insert(userList, user)
 		end
 	end
@@ -71,7 +170,7 @@ function Module:BuildRenamedUserList(guild, time)
 	return userList
 end
 
-function Module:RemoveNicknames(guild, userList)
+function Module:RemoveNicknames(guild, currentUser, userList)
 	if #userList == 0 then
 		return
 	end
@@ -81,8 +180,106 @@ function Module:RemoveNicknames(guild, userList)
 	for _, user in pairs(userList) do
 		self:LogInfo(guild, "Renaming %s", user.name)
 
-		user:setNickname('')
+		if self:HasHighestRolesThanTarget(currentUser, user) then
+			user:setNickname('')
+			return
+		end
 	end
 
 	self:LogInfo(guild, "Nickname nuke ended !")
+end
+
+function Module:BuildUserListMessage(guild, userList, currentPage)
+	local components = {}
+
+	table.sort(userList, function(u) return u._user._username end)
+
+	table.insert(components, {
+		type = enums.componentType.actionRow,
+		components = {
+			{
+				style = enums.buttonStyle.secondary,
+				label = "Real Name",
+				custom_id = "row_header_button_0",
+				disabled = true,
+				type = enums.componentType.button
+			},
+			{
+				style = enums.buttonStyle.secondary,
+				label = "Custom Name",
+				custom_id = "row_header_button_1",
+				disabled = true,
+				type = enums.componentType.button
+			},
+		}
+	})
+
+	local i = 0
+	for _, user in pairs(userList) do
+		if i >= Module.PageSize * currentPage then
+			if #components > Module.PageSize then
+				break
+			end
+
+			table.insert(components, {
+				type = enums.componentType.actionRow,
+				components = {
+					{
+						style = enums.buttonStyle.secondary,
+						label = user._user._username,
+						custom_id = "row_" .. #components .. "_button_0",
+						disabled = true,
+						type = enums.componentType.button
+					},
+					{
+						style = enums.buttonStyle.secondary,
+						label = user.nickname,
+						custom_id = "row_" .. #components .. "_button_1",
+						disabled = true,
+						type = enums.componentType.button
+					},
+					{
+						style = enums.buttonStyle.primary,
+						label = "Remove custom username",
+						custom_id = "nickname_remove_" .. user.id,
+						disabled = false,
+						type = enums.componentType.button
+					}
+				}
+			})
+		end
+		i = i+1
+	end
+
+	table.insert(components, {
+		type = enums.componentType.actionRow,
+		components = {
+			{
+				style = enums.buttonStyle.primary,
+				label = "Prev Page",
+				custom_id = "nickname_page_" .. currentPage - 1,
+				disabled = currentPage == 0,
+				type = enums.componentType.button
+			},
+			{
+				style = enums.buttonStyle.primary,
+				label = "Next Page",
+				custom_id = "nickname_page_" .. currentPage + 1,
+				disabled = #userList <= Module.PageSize * (currentPage + 1),
+				type = enums.componentType.button
+			},
+		}
+	})
+
+	return {
+		components = components,
+		embeds = {
+			{
+				type = "rich",
+				title = "Test",
+				description = "",
+				color = 0x00FFFF
+			}
+		}
+	}
 end

--- a/utils.lua
+++ b/utils.lua
@@ -211,6 +211,10 @@ function string.Explode(separator, str, withpattern)
 	return ret
 end
 
+function string.startsWith(str, start)
+   return string.sub(str, 1, string.len(start)) == start
+end
+
 function string.UpperizeFirst(str)
 	return string.upper(str:sub(1,1)) .. str:sub(2)
 end


### PR DESCRIPTION
This module adds 3 new commands:
- `!drynukerename`, a command to count every user that have a custom nickname on the server.
- `!nukerename`, a command to remove every custom nickname of every user on the server.
- `!managenicknames`, a command to list nicknames with buttons to manually reset each one.

![image](https://user-images.githubusercontent.com/7013446/177630592-520a1ae9-349f-4da5-bacb-400d462442d3.png)

Each command checks "manageNickname" permission as well as target role position compared to current user role.

Feel free to review and report any problem :)