### PR TITLE
Add ability to create a Scheduled event with Not A Bot twitch stream detection

### DIFF
--- a/deps/discordia/libs/client/API.lua
+++ b/deps/discordia/libs/client/API.lua
@@ -735,7 +735,7 @@ function API:getGuildScheduledEvent(guild_id, scheduled_event_id)
 	return self:request("GET", endpoint)
 end
 
-function API:modifyGuildScheduledEvent(guild_id, scheduled_event_id, payload)
+function API:modifyGuildScheduledEvent(guild_id, scheduled_event_id, payload) -- not exposed, maybe in the future
 	local endpoint = f(endpoints.GUILD_SCHEDULED_EVENT, guild_id, scheduled_event_id)
 	return self:request("PATCH", endpoint)
 end
@@ -745,7 +745,7 @@ function API:deleteGuildScheduledEvent(guild_id, scheduled_event_id)
 	return self:request("DELETE", endpoint)
 end
 
-function API:getGuildScheduledEventUsers(guild_id, scheduled_event_id)
+function API:getGuildScheduledEventUsers(guild_id, scheduled_event_id) -- not exposed, maybe in the future, need to manage cache and pagination here
 	local endpoint = f(endpoints.GUILD_SCHEDULED_EVENT_USER, guild_id, scheduled_event_id)
 	return self:request("GET", endpoint)
 end

--- a/deps/discordia/libs/client/API.lua
+++ b/deps/discordia/libs/client/API.lua
@@ -730,6 +730,36 @@ function API:modifyGuildEmbed(guild_id, payload) -- not exposed, maybe in the fu
 	return self:request("PATCH", endpoint, payload)
 end
 
+function API:getGuildScheduledEvent(guild_id, scheduled_event_id)
+	local endpoint = f(endpoints.GUILD_SCHEDULED_EVENT, guild_id, scheduled_event_id)
+	return self:request("GET", endpoint)
+end
+
+function API:modifyGuildScheduledEvent(guild_id, scheduled_event_id, payload)
+	local endpoint = f(endpoints.GUILD_SCHEDULED_EVENT, guild_id, scheduled_event_id)
+	return self:request("PATCH", endpoint)
+end
+
+function API:deleteGuildScheduledEvent(guild_id, scheduled_event_id)
+	local endpoint = f(endpoints.GUILD_SCHEDULED_EVENT, guild_id, scheduled_event_id)
+	return self:request("DELETE", endpoint)
+end
+
+function API:getGuildScheduledEventUsers(guild_id, scheduled_event_id)
+	local endpoint = f(endpoints.GUILD_SCHEDULED_EVENT_USER, guild_id, scheduled_event_id)
+	return self:request("GET", endpoint)
+end
+
+function API:getGuildScheduledEvents(guild_id)
+	local endpoint = f(endpoints.GUILD_SCHEDULED_EVENTS, guild_id)
+	return self:request("GET", endpoint)
+end
+
+function API:createGuildScheduledEvents(guild_id, payload)
+	local endpoint = f(endpoints.GUILD_SCHEDULED_EVENTS, guild_id)
+	return self:request("POST", endpoint, payload)
+end
+
 function API:getInvite(invite_code, query) -- Client:getInvite
 	local endpoint = f(endpoints.INVITE, invite_code)
 	return self:request("GET", endpoint, nil, query)

--- a/deps/discordia/libs/containers/Guild.lua
+++ b/deps/discordia/libs/containers/Guild.lua
@@ -706,6 +706,79 @@ function Guild:unbanUser(id, reason)
 	end
 end
 
+--[=[
+@m getScheduledEvent
+@t http
+@p eventId Event Id
+@r Event
+@d Get a scheduled event content
+]=]
+function Guild:getScheduledEvent(eventId) 
+	if eventId then
+		local data, err = self.client._api:getGuildScheduledEvent(self._id, eventId)
+
+		if data then
+			return data
+		else
+			return nil, err
+		end
+	end
+end
+
+--[=[
+@m deleteScheduledEvent
+@t http
+@p eventId Event Id
+@r Boolean
+@d Delete a scheduled event
+]=]
+function Guild:deleteScheduledEvent(eventId) 
+	if eventId then
+		local data, err = self.client._api:deleteGuildScheduledEvent(self._id, eventId)
+
+		if data then
+			return true
+		else
+			return false, err
+		end
+	end
+end
+
+--[=[
+@m getScheduledEvents
+@t http
+@r List of events
+@d Get a list of scheduled events for the server
+]=]
+function Guild:getScheduledEvents() 
+	local data, err = self.client._api:getGuildScheduledEvents(self._id)
+
+	if data then
+		return data
+	else
+		return nil, err
+	end
+end
+
+--[=[
+@m createScheduledEvents
+@t http
+@p payload Scheduled Event to create
+@r Event
+@d Create a scheduled event on the server
+]=]
+function Guild:createScheduledEvents(payload) 
+	if payload then
+		local data, err = self.client._api:createGuildScheduledEvents(self._id, payload)
+
+		if data then
+			return true
+		else
+			return false, err
+		end
+	end
+end
+
 --[=[@p shardId number The ID of the shard on which this guild is served. If only one shard is in
 operation, then this will always be 0.]=]
 function get.shardId(self)

--- a/deps/discordia/libs/containers/Guild.lua
+++ b/deps/discordia/libs/containers/Guild.lua
@@ -767,7 +767,18 @@ end
 @r Event
 @d Create a scheduled event on the server
 ]=]
-function Guild:createScheduledEvents(payload) 
+function Guild:createScheduledEvents(entity_type, location, name, privacy_level, scheduled_start_time, scheduled_end_time) 
+	local payload = {
+		entity_type = entity_type,
+		entity_metadata = {
+			location = location
+		},
+		name = name,
+		privacy_level = privacy_level,
+		scheduled_start_time = scheduled_start_time,
+		scheduled_end_time = scheduled_end_time,
+	}
+
 	if payload then
 		local data, err = self.client._api:createGuildScheduledEvents(self._id, payload)
 

--- a/deps/discordia/libs/endpoints.lua
+++ b/deps/discordia/libs/endpoints.lua
@@ -47,6 +47,9 @@ return {
 	GUILD_REGIONS                             = "/guilds/%s/regions",
 	GUILD_ROLE                                = "/guilds/%s/roles/%s",
 	GUILD_ROLES                               = "/guilds/%s/roles",
+	GUILD_SCHEDULED_EVENT                     = "/guilds/%s/scheduled-events/%s"
+	GUILD_SCHEDULED_EVENT_USER                = "/guilds/%s/scheduled-events/%s/users"
+	GUILD_SCHEDULED_EVENTS                    = "/guilds/%s/scheduled-events"
 	GUILD_WEBHOOKS                            = "/guilds/%s/webhooks",
 	INTERACTION_TOKEN_CALLBACK                = "/interactions/%s/%s/callback",
 	INVITE                                    = "/invites/%s",

--- a/deps/discordia/libs/endpoints.lua
+++ b/deps/discordia/libs/endpoints.lua
@@ -47,9 +47,9 @@ return {
 	GUILD_REGIONS                             = "/guilds/%s/regions",
 	GUILD_ROLE                                = "/guilds/%s/roles/%s",
 	GUILD_ROLES                               = "/guilds/%s/roles",
-	GUILD_SCHEDULED_EVENT                     = "/guilds/%s/scheduled-events/%s"
-	GUILD_SCHEDULED_EVENT_USER                = "/guilds/%s/scheduled-events/%s/users"
-	GUILD_SCHEDULED_EVENTS                    = "/guilds/%s/scheduled-events"
+	GUILD_SCHEDULED_EVENT                     = "/guilds/%s/scheduled-events/%s",
+	GUILD_SCHEDULED_EVENT_USER                = "/guilds/%s/scheduled-events/%s/users",
+	GUILD_SCHEDULED_EVENTS                    = "/guilds/%s/scheduled-events",
 	GUILD_WEBHOOKS                            = "/guilds/%s/webhooks",
 	INTERACTION_TOKEN_CALLBACK                = "/interactions/%s/%s/callback",
 	INVITE                                    = "/invites/%s",

--- a/deps/discordia/libs/enums.lua
+++ b/deps/discordia/libs/enums.lua
@@ -408,4 +408,16 @@ enums.applicationFlag = enum {
 	embedded                      = flag(17),
 }
 
+-- https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level
+enums.scheduledEventsPrivacyLevel = enum {
+	guild_only = 2,
+}
+
+-- https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types
+enums.scheduledEventsEntityTypes = enum {
+	stage_instance = 1,
+	voice = 2,
+	external = 3,
+}
+
 return enums

--- a/module_twitch.lua
+++ b/module_twitch.lua
@@ -80,6 +80,10 @@ function Module:GetConfigTable()
 								if (type(fieldValue) ~= "boolean") then
 									return false, "TwitchConfig[" .. channelId .. "][" .. i .. "]." .. fieldName .. " must be a boolean"
 								end
+							elseif (fieldName == "CreateDiscordEventDuration") then
+								if (type(fieldValue) ~= "number") then
+									return false, "TwitchConfig[" .. channelId .. "][" .. i .. "]." .. fieldName .. " must be a number"
+								end
 							else
 								return false, "TwitchConfig[" .. channelId .. "][" .. i .. "]." .. fieldName .. " is not a valid field"
 							end
@@ -626,6 +630,8 @@ function Module:HandleChannelNotification(channelId, channelData, type, eventDat
 				end
 
 				if(pattern.ShouldCreateDiscordEvent) then
+					local duration = pattern.CreateDiscordEventDuration or 3600
+
 					guild.createScheduledEvents({
 						entity_type = 3, --'EXTERNAL', -- TODO: use enums
 						entity_metadata = {
@@ -634,7 +640,7 @@ function Module:HandleChannelNotification(channelId, channelData, type, eventDat
 						name = title,
 						privacy_level = 2, -- 'GUILD_ONLY', -- TODO: use enums
 						scheduled_start_time = os.date("!%Y-%m-%dT%TZ"),
-						scheduled_end_time = os.date("!%Y-%m-%dT%TZ", os.time(os.date("!*t")) + 3600), -- One hour later, might need a configuration later ?
+						scheduled_end_time = os.date("!%Y-%m-%dT%TZ", os.time(os.date("!*t")) + duration),
 					})
 				end
 

--- a/module_twitch.lua
+++ b/module_twitch.lua
@@ -633,12 +633,12 @@ function Module:HandleChannelNotification(channelId, channelData, type, eventDat
 					local duration = pattern.CreateDiscordEventDuration or 3600
 
 					guild.createScheduledEvents({
-						entity_type = 3, --'EXTERNAL', -- TODO: use enums
+						entity_type = enums.scheduledEventsEntityTypes.external,
 						entity_metadata = {
 							location = string.format("https://twitch.tv/%s", channelId)
 						},
 						name = title,
-						privacy_level = 2, -- 'GUILD_ONLY', -- TODO: use enums
+						privacy_level = enums.scheduledEventsPrivacyLevel.guild_only,
 						scheduled_start_time = os.date("!%Y-%m-%dT%TZ"),
 						scheduled_end_time = os.date("!%Y-%m-%dT%TZ", os.time(os.date("!*t")) + duration),
 					})

--- a/module_twitch.lua
+++ b/module_twitch.lua
@@ -76,6 +76,10 @@ function Module:GetConfigTable()
 								if (type(fieldValue) ~= "string") then
 									return false, "TwitchConfig[" .. channelId .. "][" .. i .. "]." .. fieldName .. " must be a string"
 								end
+							elseif (fieldName == "ShouldCreateDiscordEvent") then
+								if (type(fieldValue) ~= "boolean") then
+									return false, "TwitchConfig[" .. channelId .. "][" .. i .. "]." .. fieldName .. " must be a boolean"
+								end
 							else
 								return false, "TwitchConfig[" .. channelId .. "][" .. i .. "]." .. fieldName .. " is not a valid field"
 							end
@@ -619,6 +623,19 @@ function Module:HandleChannelNotification(channelId, channelData, type, eventDat
 					end
 	
 					return true
+				end
+
+				if(pattern.ShouldCreateDiscordEvent) then
+					guild.createScheduledEvents({
+						entity_type = 3, --'EXTERNAL', -- TODO: use enums
+						entity_metadata = {
+							location = string.format("https://twitch.tv/%s", channelId)
+						},
+						name = title,
+						privacy_level = 2, -- 'GUILD_ONLY', -- TODO: use enums
+						scheduled_start_time = os.date("!%Y-%m-%dT%TZ"),
+						scheduled_end_time = os.date("!%Y-%m-%dT%TZ", os.time(os.date("!*t")) + 3600), -- One hour later, might need a configuration later ?
+					})
 				end
 
 				for _, pattern in pairs(guildPatterns) do

--- a/module_twitch.lua
+++ b/module_twitch.lua
@@ -632,15 +632,15 @@ function Module:HandleChannelNotification(channelId, channelData, type, eventDat
 				if(pattern.ShouldCreateDiscordEvent) then
 					local duration = pattern.CreateDiscordEventDuration or 3600
 
-					guild.createScheduledEvents({
+					guild:createScheduledEvents({
 						entity_type = enums.scheduledEventsEntityTypes.external,
 						entity_metadata = {
 							location = string.format("https://twitch.tv/%s", channelId)
 						},
 						name = title,
 						privacy_level = enums.scheduledEventsPrivacyLevel.guild_only,
-						scheduled_start_time = os.date("!%Y-%m-%dT%TZ"),
-						scheduled_end_time = os.date("!%Y-%m-%dT%TZ", os.time(os.date("!*t")) + duration),
+						scheduled_start_time = os.date("!%Y-%m-%dT%TZ", os.time() + 1),
+						scheduled_end_time = os.date("!%Y-%m-%dT%TZ", os.time() + duration),
 					})
 				end
 


### PR DESCRIPTION
This PR adds API to use Scheduled events and create them if needed when a Twitch stream begins.

Changelog:
- Add API endpoints/enums for scheduled events
- Expose those endpoints to the bot
- Create an event if ShouldCreateDiscordEvent is checked in TwitchConfig
- Event duration is CreateDiscordEventDuration or 3600 by default

Events examples:
![image](https://user-images.githubusercontent.com/7013446/235296201-bff8a388-3bd4-4ca1-8df5-2559e277bbdf.png)
![image](https://user-images.githubusercontent.com/7013446/235296213-7141d6f7-c9bf-4300-9ef0-dfa56f728215.png)

Tested with a custom command as I can't test real twitch notifications.

The custom command:

```
	self:RegisterCommand({
		Name = "testa",
		Silent = false,
		Args = {
		},
		Help = "Test things",
		Func = function(commandMessage, channel)
			commandMessage:reply("ok")

			commandMessage.guild:createScheduledEvents(
				enums.scheduledEventsEntityTypes.external,
				string.format("https://twitch.tv/%s", "elanis42"),
				"Test title",
				enums.scheduledEventsPrivacyLevel.guild_only,
				os.date("!%Y-%m-%dT%TZ", os.time() + 1),
				os.date("!%Y-%m-%dT%TZ", os.time() + 3600)
			)
		end
	})
```