### PR TITLE
use the Bot.ConfigType.Message type in module prune

### DIFF
--- a/bot_utility.lua
+++ b/bot_utility.lua
@@ -84,15 +84,15 @@ function Bot:DecodeMember(guild, message)
 	return member
 end
 
-function Bot:DecodeMessage(message, ignoreEscaped, fullContent)
-	assert(message)
+function Bot:DecodeMessage(messageContent, ignoreEscaped, fullContent)
+	assert(messageContent)
 
 	local pattern = "(<?)https?://([%w%.]+)/channels/(%d+)/(%d+)/(%d+)(>?)"
 	if (fullContent) then
 		pattern = "^" .. pattern .. "$"
 	end
 
-	local e1, domain, guildId, channelId, messageId, e2 = message:match(pattern)
+	local e1, domain, guildId, channelId, messageId, e2 = messageContent:match(pattern)
 	if (not e1 or not discordDomains[domain]) then
 		return nil, "Invalid link"
 	end

--- a/localization/en.lua
+++ b/localization/en.lua
@@ -76,7 +76,6 @@ return {
 			"messageId: The message id"
 		),
 		PRUNE_CANNOT_DELETE = "ℹ️ Some messages could not be deleted.",
-		PRUNE_BAD_MESSAGE_ID = "❌ No message with the specified ID was found.",
 		PRUNE_HELP = string.format("%s\n%s\n\t%s",
 			"Delete the nth last messages.",
 			"Arguments:",

--- a/localization/fr.lua
+++ b/localization/fr.lua
@@ -237,7 +237,6 @@ return {
             "messageId: L'identifiant du message"
         ),
 		PRUNE_CANNOT_DELETE = "ℹ️ Certains messages n'ont pas pu être supprimés.",
-		PRUNE_BAD_MESSAGE_ID = "❌ Aucun message avec l'identifiant spécifié n'a été trouvé.",
 		PRUNE_HELP = string.format("%s\n%s\n\t%s",
 			"Supprime les n derniers messages.",
 			"Arguments:",

--- a/module_prune.lua
+++ b/module_prune.lua
@@ -115,24 +115,20 @@ function Module:OnLoaded()
 	self:RegisterCommand({
 		Name = "prunefrom",
 		Args = {
-			{ Name = "<messageId>", Type = Bot.ConfigType.String }
+			{ Name = "<messageId>", Type = Bot.ConfigType.Message }
 		},
 		PrivilegeCheck = hasManagePermission,
 		Help = function (guild) return Bot:Format(guild, "PRUNEFROM_HELP") end,
 		Silent = true,
-		Func = function (commandMessage, messageId)
+		Func = function (commandMessage, targetMessage)
 			local guild = commandMessage.guild
-
-			local targetMessage = commandMessage.channel:getMessage(messageId)
-			if targetMessage == nil then
-				return  commandMessage:reply(Bot:Format(guild, "PRUNE_BAD_MESSAGE_ID"))
-			end
-
 			local nbDeletedMessages = self:bulkDeleteById(commandMessage, targetMessage)
+
 			local response = "";
 			if not hasValidDate(targetMessage) then
 				response = string.format("%s\n", Bot:Format(guild, "PRUNE_CANNOT_DELETE"))
 			end
+
 			response = response .. Bot:Format(guild, "PRUNE_RESULT", nbDeletedMessages)
 
 			return commandMessage:reply(response)


### PR DESCRIPTION
I have also renamed a parameter in Bot:DecodeMessage to avoid confusion, this parameter is not a message object and a local variable with the same name already exists inside the function.