### PR TITLE
do not trigger autoquote module when writting a command message

### DIFF
--- a/bot_commands.lua
+++ b/bot_commands.lua
@@ -19,7 +19,7 @@ function Bot:BuildUsage(commandTable)
 	return table.concat(usage, " ")
 end
 
-function Bot:ParseCommandArgs(member, expectedArgs, args)	
+function Bot:ParseCommandArgs(member, expectedArgs, args)
 	local parsers = self.ConfigTypeParameter
 
 	local values = {}
@@ -78,7 +78,7 @@ function Bot:UnregisterCommand(commandName)
 	self.Commands[commandName:lower()] = nil
 end
 
-local prefixes = { 
+local prefixes = {
 	function (content, guild)
 		local prefix = Config.Prefix
 		if guild then

--- a/module_quote.lua
+++ b/module_quote.lua
@@ -6,6 +6,8 @@ local client = Client
 local discordia = Discordia
 local bot = Bot
 local enums = discordia.enums
+local prefix = Config.Prefix
+
 
 Module.Name = "quote"
 
@@ -74,11 +76,6 @@ function Module:OnLoaded()
 					return
 				end
 
-				if (config.AutoQuote) then
-					-- Autoquote will quote this link automatically, ignore it
-					return
-				end		
-
 				-- Checks if user has permission to see this message
 				if (not self:CheckReadPermission(commandMessage.author, quotedMessage)) then
 					commandMessage:reply("You can only quote messages you are able to see yourself")
@@ -135,6 +132,10 @@ function Module:OnMessageCreate(message)
 	end
 
 	if (message.author.bot) then
+		return
+	end
+
+	if (message.content:startswith(prefix, true)) then
 		return
 	end
 


### PR DESCRIPTION
stop triggering the autoquote when using !prunefrom or other commands that take a message link as parameter