### PR TITLE
Fix some bugs in module warn

### DIFF
--- a/bot_utility.lua
+++ b/bot_utility.lua
@@ -227,18 +227,18 @@ end
 function Bot:UnserializeFromFile(filepath)
 	local saveFile, err = io.open(filepath, "r")
 	if (not saveFile) then
-		return nil, string.format("Failed to open %s: %s", filepath, err) 
+		return nil, string.format("Failed to open %s: %s", filepath, err)
 	end
 
 	local content, err = saveFile:read("*a")
 	if (not content) then
-		return nil, string.format("Failed to read %s content: %s", filepath, err) 
+		return nil, string.format("Failed to read %s content: %s", filepath, err)
 	end
 	saveFile:close()
 
 	local success, contentOrErr = pcall(json.decode, content)
 	if (not success) then
-		return nil, string.format("Failed to unserialize %s content: %s", filepath, contentOrErr) 
+		return nil, string.format("Failed to unserialize %s content: %s", filepath, contentOrErr)
 	end
 
 	return contentOrErr
@@ -296,7 +296,7 @@ function Bot:BuildQuoteEmbed(message, opt)
 	end
 
 	local fields
-	local imageUrl 
+	local imageUrl
 	if (message.attachments) then
 		local images = {}
 		local files = {}
@@ -393,7 +393,7 @@ function Bot:BuildQuoteEmbed(message, opt)
 			return mention
 		else
 			return ":" .. emojiName .. ":"
-		end			
+		end
 	end)
 
 	if (#content > maxContentSize) then
@@ -513,7 +513,7 @@ function Bot:MessagesToTable(messages)
 			components = message.components,
 			tts = message.tts or nil
 		}
-	
+
 		local embed = message.embed
 		if (embed) then
 			embed.type = nil

--- a/module_warn.lua
+++ b/module_warn.lua
@@ -247,9 +247,9 @@ function Module:OnLoaded()
 				local message = string.format("Warns of **%s** (%d)\n", targetMember.tag, targetMember.id)
 				local warns = memberHistory.Warns
 				for _idx, warn in ipairs(warns) do
-					local moderator = guild:getMember(warn.From)
+					local warnedBy = client:getUser(warn.From)
 					local reason = warn.Reason or "No reason provided"
-					message = message .. string.format("Warned by : **%s** for the reason:\n\t**%s**\n", moderator.tag, reason)
+					message = message .. string.format("Warned by : **%s** for the reason:\n\t**%s**\n", warnedBy.tag, reason)
 				end
 				commandMessage:reply(message)
 			end

--- a/module_warn.lua
+++ b/module_warn.lua
@@ -13,277 +13,276 @@ Module.Name = "warn"
 --  Storage Model
 --
 --  [
---      {
---          UserId: memberId,
---          Warns: {
---              {From: moderatorId, Reason: "...."},
---              ...
---          }
---      },
---      ...
+--	  {
+--		  UserId: memberId,
+--		  Warns: {
+--			  {From: moderatorId, Reason: "...."},
+--			  ...
+--		  }
+--	  },
+--	  ...
 --  ]
 
 local function FindMember(history, memberId)
-    local result = nil
-    for _idx, userHistory in ipairs(history) do
-        if userHistory.UserId == memberId then
-            result = userHistory
-            break
-        end
-    end
-    return result
+	local result = nil
+	for _idx, userHistory in ipairs(history) do
+		if userHistory.UserId == memberId then
+			result = userHistory
+			break
+		end
+	end
+	return result
 end
 
 local function AddWarn(history, memberId, moderatorId, reason)
-    local member = FindMember(history, memberId)
-    if (not member) then
-        table.insert(history, {
-            UserId = memberId,
-            Warns = {
-                {
-                    From = moderatorId,
-                    Reason = reason,
-                }
-            }
-        })
-    else
-        table.insert(member.Warns, {
-            From = moderatorId,
-            Reason = reason,
-        })
-    end
+	local member = FindMember(history, memberId)
+	if (not member) then
+		table.insert(history, {
+			UserId = memberId,
+			Warns = {
+				{
+					From = moderatorId,
+					Reason = reason,
+				}
+			}
+		})
+	else
+		table.insert(member.Warns, {
+			From = moderatorId,
+			Reason = reason,
+		})
+	end
 end
 
 local function GetWarnAmount(history, memberId)
-    local member = FindMember(history, memberId)
-    return table.length(member.Warns)
+	local member = FindMember(history, memberId)
+	return table.length(member.Warns)
 end
 
 local function SendWarnMessage(commandMessage, targetMember, reason, warnAmount)
-    if not reason then
-        commandMessage:reply(string.format("**%s** has warned **%s** (warn #%d).", commandMessage.member.tag, targetMember.tag, warnAmount))
-    else
-        commandMessage:reply(string.format("**%s** has warned **%s** (warn #%d) for the following reason:\n**%s**.", commandMessage.member.tag, targetMember.tag, warnAmount, reason))
-    end
+	if not reason then
+		commandMessage:reply(string.format("**%s** has warned **%s** (warn #%d).", commandMessage.member.tag, targetMember.tag, warnAmount))
+	else
+		commandMessage:reply(string.format("**%s** has warned **%s** (warn #%d) for the following reason:\n**%s**.", commandMessage.member.tag, targetMember.tag, warnAmount, reason))
+	end
 end
 
 --------------------------------
 
 function Module:CheckPermissions(member)
-    return member:hasPermission(enums.permission.banMembers)
+	return member:hasPermission(enums.permission.banMembers)
 end
 
 function Module:GetConfigTable()
 
-    return {
-        {
-            Name = "Sanctions",
-            Description = "Enable sanctions over members.",
-            Type = bot.ConfigType.Boolean,
-            Default = true
-        },
-        {
-            Name = "WarnAmountToMute",
-            Description = "Number of warns needed to mute the member.",
-            Type = bot.ConfigType.Integer,
-            Default = 3
-        },
-        {
-            Name = "WarnAmountToBan",
-            Description = "Number of warns needed to tempban the member.",
-            Type = bot.ConfigType.Integer,
-            Default = 9,
-        },
-        {
-            Name = "DefaultMuteDuration",
-            Description = "Default mute duration when reached enough warns.",
-            Type = bot.ConfigType.Duration,
-            Default = 60 * 60
-        },
-        {
-            Name = "BanInformationChannel",
-            Description = "Default channel where all the ban-able members are listed.",
-            Type = bot.ConfigType.Channel,
-            Default = ""
-        },
-        {
-            Name = "SendPrivateMessage",
-            Description = "Sends the warning to the user in private message.",
-            Type = bot.ConfigType.Boolean,
-            Default = true
-        }
-    }
+	return {
+		{
+			Name = "Sanctions",
+			Description = "Enable sanctions over members.",
+			Type = bot.ConfigType.Boolean,
+			Default = true
+		},
+		{
+			Name = "WarnAmountToMute",
+			Description = "Number of warns needed to mute the member.",
+			Type = bot.ConfigType.Integer,
+			Default = 3
+		},
+		{
+			Name = "WarnAmountToBan",
+			Description = "Number of warns needed to tempban the member.",
+			Type = bot.ConfigType.Integer,
+			Default = 9,
+		},
+		{
+			Name = "DefaultMuteDuration",
+			Description = "Default mute duration when reached enough warns.",
+			Type = bot.ConfigType.Duration,
+			Default = 60 * 60
+		},
+		{
+			Name = "BanInformationChannel",
+			Description = "Default channel where all the ban-able members are listed.",
+			Type = bot.ConfigType.Channel,
+			Default = ""
+		},
+		{
+			Name = "SendPrivateMessage",
+			Description = "Sends the warning to the user in private message.",
+			Type = bot.ConfigType.Boolean,
+			Default = true
+		}
+	}
 
 end
 
 function Module:OnEnable(guild)
-    local data = self:GetPersistentData(guild)
-    data = data or {}
+	local data = self:GetPersistentData(guild)
+	data = data or {}
 
-    local config = self:GetConfig(guild)
+	local config = self:GetConfig(guild)
 
-    local banInfo = config.BanInformationChannel and guild:getChannel(config.BanInformationChannel) or nil
-    if not banInfo then
-        return false, "Invalid ban information channel, check your configuration."
-    end
+	local banInfo = config.BanInformationChannel and guild:getChannel(config.BanInformationChannel) or nil
+	if not banInfo then
+		return false, "Invalid ban information channel, check your configuration."
+	end
 
-    return true
+	return true
 end
 
 function Module:OnLoaded()
 
-    --
-    --  warn command
-    --
-    self:RegisterCommand({
-        Name = "warn",
-        Args = {
-            {Name = "target", Type = bot.ConfigType.User},
-            {Name = "reason", Type = bot.ConfigType.String, Optional = true}
-        },
-        PrivilegeCheck = function (member) return self:CheckPermissions(member) end,
+	--
+	--  warn command
+	--
+	self:RegisterCommand({
+		Name = "warn",
+		Args = {
+			{Name = "target", Type = bot.ConfigType.User},
+			{Name = "reason", Type = bot.ConfigType.String, Optional = true}
+		},
+		PrivilegeCheck = function (member) return self:CheckPermissions(member) end,
 
-        Help = "Warns a member",
-        Silent = true,
-        Func = function (commandMessage, targetUser, reason)
-            local guild = commandMessage.guild
-            local config = self:GetConfig(guild)
-            local history = self:GetPersistentData(guild)
-            history = history or {}
-            
-            local targetMember = guild:getMember(targetUser)
-            local moderator = commandMessage.member
-            
-            -- Permission check
-            if targetMember then
-                local bannedByRole = moderator.highestRole
-                local targetRole = targetMember.highestRole
-                if targetRole.position >= bannedByRole.position then
-                    commandMessage:reply("You cannot warn this user due to your lower permissions.")
-                    return
-                end
-            end
+		Help = "Warns a member",
+		Silent = true,
+		Func = function (commandMessage, targetUser, reason)
+			local guild = commandMessage.guild
+			local config = self:GetConfig(guild)
+			local history = self:GetPersistentData(guild)
+			history = history or {}
 
-            -- Adding warn to the user
-            local targetId = targetUser.id
-            local moderatorId = commandMessage.member.id
-            
-            AddWarn(history, targetId, moderatorId, reason)
+			local targetMember = guild:getMember(targetUser)
+			local moderator = commandMessage.member
 
+			-- Permission check
+			if targetMember then
+				local bannedByRole = moderator.highestRole
+				local targetRole = targetMember.highestRole
+				if targetRole.position >= bannedByRole.position then
+					commandMessage:reply("You cannot warn this user due to your lower permissions.")
+					return
+				end
+			end
 
-            if config.SendPrivateMessage then
-                local privateChannel = targetUser:getPrivateChannel()
-                if privateChannel then
-                    if reason then
-                        privateChannel:send(string.format("You have been warned on %s for the following reason:\n **%s**", guild.name, reason))
-                    else
-                        privateChannel:send(string.format("You have been warned on %s", guild.name))
-                    end
-                end
-            end
+			-- Adding warn to the user
+			local targetId = targetUser.id
+			local moderatorId = commandMessage.member.id
 
-            local warnAmount = GetWarnAmount(history, targetId)
+			AddWarn(history, targetId, moderatorId, reason)
 
-            -- Updating member state
-            SendWarnMessage(commandMessage, targetMember, reason, warnAmount)
-            
-            if config.Sanctions then
-                local banAmount = config.WarnAmountToBan
-                local muteAmount = config.WarnAmountToMute
+			if config.SendPrivateMessage then
+				local privateChannel = targetUser:getPrivateChannel()
+				if privateChannel then
+					if reason then
+						privateChannel:send(string.format("You have been warned on %s for the following reason:\n **%s**", guild.name, reason))
+					else
+						privateChannel:send(string.format("You have been warned on %s", guild.name))
+					end
+				end
+			end
 
-                if warnAmount % banAmount == 0 then
-                    -- BAN
-                    local channel = guild:getChannel(config.BanInformationChannel)
-                    if channel then
-                        channel:send(string.format("The member **%s** ( %d ) has enough warns to be banned (%d warns).",
-                            targetMember.tag,
-                            targetMember.id,
-                            warnAmount
-                        ))
-                    end
+			local warnAmount = GetWarnAmount(history, targetId)
 
-                elseif warnAmount % muteAmount == 0 then
-                    -- MUTE
-                    local duration = config.DefaultMuteDuration * (warnAmount / muteAmount)
-                    local mute_module = bot:GetModuleForGuild(guild, "mute")
+			-- Updating member state
+			SendWarnMessage(commandMessage, targetMember, reason, warnAmount)
 
-                    if mute_module then
-                        local channel = guild:getChannel(config.BanInformationChannel)
-                        if channel then
-                            channel:send(string.format("The member **%s** ( %d ) has enough warns to be muted (%d warns) %s.",
-                                targetMember.tag,
-                                targetMember.id,
-                                warnAmount,
-                                util.DiscordRelativeTime(duration)
-                            ))
-                        end
-                        bot:CallModuleFunction(mute_module, "Mute", guild, targetMember.id, duration)
-                    end
-                end
-            end
-        end
-    })
+			if config.Sanctions then
+				local banAmount = config.WarnAmountToBan
+				local muteAmount = config.WarnAmountToMute
 
-    --
-    --  warnlist command
-    --
-    self:RegisterCommand({
-        Name = "warnlist",
-        Args = {
-            {Name = "targetUser", Type = bot.ConfigType.User}
-        },
-        PrivilegeCheck = function (member) return self:CheckPermissions(member) end,
+				if warnAmount % banAmount == 0 then
+					-- BAN
+					local channel = guild:getChannel(config.BanInformationChannel)
+					if channel then
+						channel:send(string.format("The member **%s** ( %d ) has enough warns to be banned (%d warns).",
+							targetMember.tag,
+							targetMember.id,
+							warnAmount
+						))
+					end
 
-        Help = "Shows all the warns of a member.",
-        Silent = true,
-        Func = function(commandMessage, targetUser)
-            local guild = commandMessage.guild
-            local history = self:GetPersistentData(guild)
-            local targetMember = guild:getMember(targetUser)
+				elseif warnAmount % muteAmount == 0 then
+					-- MUTE
+					local duration = config.DefaultMuteDuration * (warnAmount / muteAmount)
+					local mute_module = bot:GetModuleForGuild(guild, "mute")
 
-            local memberHistory = FindMember(history, targetMember.id)
-            if not memberHistory then
-                commandMessage:reply(string.format("The member **%s** (%d) doesn't have any warns.", targetMember.tag, targetMember.id))
-            else
-                local message = string.format("Warns of **%s** (%d)\n", targetMember.tag, targetMember.id)
-                local warns = memberHistory.Warns
-                for _idx, warn in ipairs(warns) do
-                    local moderator = guild:getMember(warn.From)
-                    local reason = warn.Reason or "No reason provided"
-                    message = message .. string.format("Warned by : **%s** for the reason:\n\t**%s**\n", moderator.tag, reason)
-                end
-                commandMessage:reply(message)
-            end
-        end
-    })
+					if mute_module then
+						local channel = guild:getChannel(config.BanInformationChannel)
+						if channel then
+							channel:send(string.format("The member **%s** ( %d ) has enough warns to be muted (%d warns) %s.",
+								targetMember.tag,
+								targetMember.id,
+								warnAmount,
+								util.DiscordRelativeTime(duration)
+							))
+						end
+						bot:CallModuleFunction(mute_module, "Mute", guild, targetMember.id, duration)
+					end
+				end
+			end
+		end
+	})
 
-    --
-    --  clearwarns command
-    --
-    self:RegisterCommand({
-        Name = "clearwarns",
-        Args = {
-            {Name = "targetUser", Type = bot.ConfigType.User}
-        },
-        PrivilegeCheck = function (member) return self:CheckPermissions(member) end,
+	--
+	--  warnlist command
+	--
+	self:RegisterCommand({
+		Name = "warnlist",
+		Args = {
+			{Name = "targetUser", Type = bot.ConfigType.User}
+		},
+		PrivilegeCheck = function (member) return self:CheckPermissions(member) end,
 
-        Help = "Clears all the warns of a specified user.",
-        Silent = true,
-        Func = function (commandMessage, targetUser)
-            local guild = commandMessage.guild
-            local history = self:GetPersistentData(guild)
-            local targetMember = guild:getMember(targetUser)
+		Help = "Shows all the warns of a member.",
+		Silent = true,
+		Func = function(commandMessage, targetUser)
+			local guild = commandMessage.guild
+			local history = self:GetPersistentData(guild)
+			local targetMember = guild:getMember(targetUser)
 
-            local memberHistory = FindMember(history, targetMember.id)
-            if not memberHistory then
-                commandMessage:reply(string.format("The member **%s** (%d) already have zero warns.", targetMember.tag, targetMember.id))
-            else
-                memberHistory.Warns = {}
-                commandMessage:reply(string.format("Cleared **%s** (%d) warns, saving.", targetMember.tag, targetMember.id))
-                bot:Save()
-            end
-        end
-    })
+			local memberHistory = FindMember(history, targetMember.id)
+			if not memberHistory then
+				commandMessage:reply(string.format("The member **%s** (%d) doesn't have any warns.", targetMember.tag, targetMember.id))
+			else
+				local message = string.format("Warns of **%s** (%d)\n", targetMember.tag, targetMember.id)
+				local warns = memberHistory.Warns
+				for _idx, warn in ipairs(warns) do
+					local moderator = guild:getMember(warn.From)
+					local reason = warn.Reason or "No reason provided"
+					message = message .. string.format("Warned by : **%s** for the reason:\n\t**%s**\n", moderator.tag, reason)
+				end
+				commandMessage:reply(message)
+			end
+		end
+	})
 
-    return true
+	--
+	--  clearwarns command
+	--
+	self:RegisterCommand({
+		Name = "clearwarns",
+		Args = {
+			{Name = "targetUser", Type = bot.ConfigType.User}
+		},
+		PrivilegeCheck = function (member) return self:CheckPermissions(member) end,
+
+		Help = "Clears all the warns of a specified user.",
+		Silent = true,
+		Func = function (commandMessage, targetUser)
+			local guild = commandMessage.guild
+			local history = self:GetPersistentData(guild)
+			local targetMember = guild:getMember(targetUser)
+
+			local memberHistory = FindMember(history, targetMember.id)
+			if not memberHistory then
+				commandMessage:reply(string.format("The member **%s** (%d) already have zero warns.", targetMember.tag, targetMember.id))
+			else
+				memberHistory.Warns = {}
+				commandMessage:reply(string.format("Cleared **%s** (%d) warns, saving.", targetMember.tag, targetMember.id))
+				bot:Save()
+			end
+		end
+	})
+
+	return true
 end


### PR DESCRIPTION
- fix: the warn module crashes when the `warnlist` command is used on a member who has been warned by a moderator who has left the guild
- update: the structure of the file `persistentData` has changed, making add and deletion of user entries easier
- add: a temporary function `ConvertDataFormat` has been added to convert persistentData format to the new format
- fix: when the `clearwarns` command is used, the warnings are removed from the file but the user's entry is not deleted, so the `persistentData` file grows indefinitely