### PR TITLE
add: commands pin and unpin

### DIFF
--- a/localization/en.lua
+++ b/localization/en.lua
@@ -70,6 +70,19 @@ return {
 		RAID_AUTOBAN_BOT_REASON = "auto-ban for bot suspicion",
 		RAID_AUTOMUTE_SPAM_REASON = "🙊 %s has been auto-muted because of spam in %s",
 
+		PIN_PIN_HELP    = string.format("%s\n%s\n\t%s",
+			"Pin a message.",
+			"Arguments:",
+			"messageId: The link of the message to pin"
+		),
+		PIN_PIN_ERROR   = "❌ Unable to pin this message.",
+		PIN_UNPIN_HELP  = string.format("%s\n%s\n\t%s",
+			"Unpin a message",
+			"Arguments:",
+			"messageId: The link of the message to unpin"
+		),
+		PIN_UNPIN_ERROR = "❌ Unable to unpin this message.",
+
 		PRUNEFROM_HELP = string.format("%s\n%s\n\t%s",
 			"Delete all messages from the one whose identifier has been given in parameter.",
 			"Arguments:",

--- a/localization/fr.lua
+++ b/localization/fr.lua
@@ -231,11 +231,24 @@ return {
 		RAID_AUTOBAN_BOT_REASON = "auto-ban pour soupçon de bot",
 		RAID_AUTOMUTE_SPAM_REASON = "🙊 %s a été auto-mute à cause de spam dans %s",
 
+		PIN_PIN_HELP    = string.format("%s\n%s\n\t%s",
+			"Épingle un message.",
+			"Arguments:",
+			"messageId: Le lien du message à épingler"
+		),
+		PIN_PIN_ERROR   = "❌ Impossible d'épingler ce message.",
+		PIN_UNPIN_HELP  = string.format("%s\n%s\n\t%s",
+			"Désépingle un message",
+			"Arguments:",
+			"messageId: Le lien du message à désépingler"
+		),
+		PIN_UNPIN_ERROR = "❌ Impossible de désépingler ce message.",
+
 		PRUNEFROM_HELP = string.format("%s\n%s\n\t%s",
-            "Supprime tous les messages à partir de celui dont l'identifiant a été passé en paramètre.",
-            "Arguments:",
-            "messageId: L'identifiant du message"
-        ),
+			"Supprime tous les messages à partir de celui dont l'identifiant a été passé en paramètre.",
+			"Arguments:",
+			"messageId: L'identifiant du message"
+		),
 		PRUNE_CANNOT_DELETE = "ℹ️ Certains messages n'ont pas pu être supprimés.",
 		PRUNE_HELP = string.format("%s\n%s\n\t%s",
 			"Supprime les n derniers messages.",

--- a/module_pin.lua
+++ b/module_pin.lua
@@ -144,3 +144,52 @@ function Module:OnReactionAddUncached(channel, messageId, reactionIdorName, user
 
 	self:HandleEmojiAdd(config, reaction)
 end
+
+function Module:OnLoaded()
+	self:RegisterCommand({
+		Name = "pin",
+		Args = {
+			{ Name = "<messageId>", Type = bot.ConfigType.Message },
+		},
+
+		Help = function (guild) return Bot:Format(guild, "PIN_PIN_HELP") end,
+		Silent = true,
+		Func = function (commandMessage, targetMessage)
+			local guild = commandMessage.guild
+			local sender = commandMessage.member
+			local senderId = sender.id
+			local channelOwnerId = commandMessage.channel._owner_id
+
+			if (sender:hasPermission(enums.permission.manageMessages) or senderId == channelOwnerId) then
+				local res = targetMessage:pin()
+				if not res then
+					commandMessage:reply(Bot:Format(guild, "PIN_PIN_ERROR"))
+				end
+			end
+		end
+	})
+
+	self:RegisterCommand({
+		Name = "unpin",
+		Args = {
+			{ Name = "<messageId>", Type = bot.ConfigType.Message },
+		},
+
+		Help = function (guild) return Bot:Format(guild, "PIN_UNPIN_HELP") end,
+		Silent = true,
+		Func = function (commandMessage, targetMessage)
+			local sender = commandMessage.member
+			local senderId = sender.id
+			local channelOwnerId = commandMessage.channel._owner_id
+
+			if (sender:hasPermission(enums.permission.manageMessages) or senderId == channelOwnerId) then
+				local res = targetMessage:unpin()
+				if not res then
+					commandMessage:reply(Bot:Format(guild, "PIN_UNPIN_ERROR"))
+				end
+			end
+		end
+	})
+
+	return true
+end


### PR DESCRIPTION
These new commands allow the owner of a thread to pin and unpin messages in his thread. The members with permission "manageMessages" can also use them.
cf: https://github.com/NotANameServer/discord/issues/51