### PR TITLE
Fix nickname logging spam

### DIFF
--- a/module_logs.lua
+++ b/module_logs.lua
@@ -149,7 +149,7 @@ function Module:OnMemberUpdate(member)
     local data = self:GetData(guild)
 
 	-- Ignore the first nickname change because new members tend to change it directly after joining which generates a lot of useless logs
-    if data.nicknames[member.id] ~= nil and data.nicknames[member.id] ~= member.nickname then
+    if data.nicknames[member.id] ~= nil and data.nicknames[member.id] ~= member.name then
         logChannel:send({
             embed = {
                 title = "Nickname changed",


### PR DESCRIPTION
```lua
    if data.nicknames[member.id] ~= nil and data.nicknames[member.id] ~= member.nickname then
        logChannel:send({
            embed = {
                title = "Nickname changed",
                description = string.format("%s - `%s` → `%s`", member.mentionString, data.nicknames[member.id], member.name),
                timestamp = discordia.Date():toISO('T', 'Z')
            }
        })
    end

    -- [...]

    data.nicknames[member.id] = member.name
```
This condition is comparing the nickname instead of name, which makes the bot logging a nickname change every time a member updates itself.