### PR TITLE
Fix the embed of the help command for admins

### DIFF
--- a/deps/discordia/libs/containers/Message.lua
+++ b/deps/discordia/libs/containers/Message.lua
@@ -298,6 +298,7 @@ sent by other users).
 function Message:update(data)
 	return self:_modify({
 		content = data.content or null,
+		components = data.components or null,
 		embed = data.embed or null,
 		allowed_mentions = {
 			parse = {'users', 'roles', 'everyone'},

--- a/localization/en.lua
+++ b/localization/en.lua
@@ -4,6 +4,10 @@ return {
 	Locs = {
 		GLOBAL_DEFAULT_REASON                     = "No reason provided.",
 
+		BOT_HELP_HELP                             = "Print commands list.",
+		BOT_HELP_NEXT_BUTTON_LABEL                = "Next Page",
+		BOT_HELP_PREV_BUTTON_LABEL                = "Previous Page",
+
 		CLEAN_URLS_NO_RULE_PROVIDED               = "No rule provided",
 		CLEAN_URLS_NO_RULES_PROVIDED              = "No rules provided",
 		CLEAN_URLS_RULE_ADDED                     = "Added rule: `%s`",

--- a/localization/fr.lua
+++ b/localization/fr.lua
@@ -165,6 +165,10 @@ return {
 	Locs = {
 		GLOBAL_DEFAULT_REASON                     = "Aucune raison donnée.",
 
+		BOT_HELP_HELP                             = "Affiche la liste des commandes.",
+		BOT_HELP_NEXT_BUTTON_LABEL                = "Page Suivante",
+		BOT_HELP_PREV_BUTTON_LABEL                = "Page Précédente",
+
 		CLEAN_URLS_NO_RULE_PROVIDED               = "Aucune règle fournie",
 		CLEAN_URLS_NO_RULES_PROVIDED              = "Aucune règles fournies",
 		CLEAN_URLS_RULE_ADDED                     = "Règle ajoutée : `%s`",


### PR DESCRIPTION
The "help" command cannot actually display all commands in an embed because there are too many. This PR fixes this issue by paging the embed.